### PR TITLE
Forced unwrap of bittrex api response causes a crash

### DIFF
--- a/ravenwallet/BRAPIClient+Wallet.swift
+++ b/ravenwallet/BRAPIClient+Wallet.swift
@@ -62,14 +62,16 @@ extension BRAPIClient {
                 if error == nil,
                     let data = data,
                     let parsedData = try JSONSerialization.jsonObject(with: data, options: []) as? [String:Any]  {
-                    let lastTradeRate = parsedData["lastTradeRate"] as! String
-                    //print("lastTradeRate \(lastTradeRate)")
-                    guard let ratio : Double = Double(lastTradeRate) else {
-                        return handler(0.00, "Error getting RVN rate in BTC")
-                    }
+                    
+                    if let lastTradeRate = parsedData["lastTradeRate"] as? String {
+                        //print("lastTradeRate \(lastTradeRate)")
+                        guard let ratio: Double = Double(lastTradeRate) else {
+                            return handler(0.00, "Error getting RVN rate in BTC")
+                        }
 
-                    print("Bittrex Ratio of BTC to RVN\(ratio)");
-                    return handler(ratio, nil)
+                        print("Bittrex Ratio of BTC to RVN\(ratio)");
+                        return handler(ratio, nil)
+                    }
                 } else {
                     return handler(0.00, "Error fetching Ravencoin BTC price from Bittrex.")
                 }


### PR DESCRIPTION
Recently the bittrex api was down for maintenance. During their maintenance, instead of returning the price of rvn in btc the json response was `{"code":"SCHEDULED_MAINTENANCE"}`.  This caused a crash as the app was expecting to find the key `lastTreadeRate` in the response. The new code handles the case better and will return an error if they key is not found.