### PR TITLE
Whitelist/blacklist assets

### DIFF
--- a/Ravencoin.xcodeproj/project.pbxproj
+++ b/Ravencoin.xcodeproj/project.pbxproj
@@ -70,6 +70,13 @@
 		22C431341DF89DFE0017CAEA /* BRCoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C431331DF89DFE0017CAEA /* BRCoderTests.swift */; };
 		22C431361DF8A6DF0017CAEA /* BRAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C431351DF8A6DF0017CAEA /* BRAPIClientTests.swift */; };
 		22E773041EE7813000397E0E /* Bonjour.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E773031EE7813000397E0E /* Bonjour.swift */; };
+		326F8C262471A87A005D91EA /* CoreDatabaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326F8C252471A87A005D91EA /* CoreDatabaseTest.swift */; };
+		32D2F9FA24721CC30075AF0B /* AssetManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D2F9F924721CC30075AF0B /* AssetManagerTest.swift */; };
+		32D2F9FC24723FA70075AF0B /* AssetFilterTableVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D2F9FB24723FA60075AF0B /* AssetFilterTableVC.swift */; };
+		32D2F9FE24724CCF0075AF0B /* AssetFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D2F9FD24724CCF0075AF0B /* AssetFilterCell.swift */; };
+		32D2FA00247391A30075AF0B /* AssetFilterAdapterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D2F9FF247391A30075AF0B /* AssetFilterAdapterProtocol.swift */; };
+		32D2FA03247392210075AF0B /* WhitelistAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D2FA02247392210075AF0B /* WhitelistAdapter.swift */; };
+		32D2FA0524745F1F0075AF0B /* BlacklistAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D2FA0424745F1F0075AF0B /* BlacklistAdapter.swift */; };
 		4106E6C8220D892200C29B86 /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4106E6C6220D892100C29B86 /* Fabric.framework */; };
 		4106E6C9220D892200C29B86 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4106E6C7220D892100C29B86 /* Crashlytics.framework */; };
 		41085231216965F30027DB2A /* AddressBookFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41085230216965F30027DB2A /* AddressBookFooterView.swift */; };
@@ -810,6 +817,13 @@
 		22C431331DF89DFE0017CAEA /* BRCoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRCoderTests.swift; sourceTree = "<group>"; };
 		22C431351DF8A6DF0017CAEA /* BRAPIClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRAPIClientTests.swift; sourceTree = "<group>"; };
 		22E773031EE7813000397E0E /* Bonjour.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bonjour.swift; sourceTree = "<group>"; };
+		326F8C252471A87A005D91EA /* CoreDatabaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDatabaseTest.swift; sourceTree = "<group>"; };
+		32D2F9F924721CC30075AF0B /* AssetManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetManagerTest.swift; sourceTree = "<group>"; };
+		32D2F9FB24723FA60075AF0B /* AssetFilterTableVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetFilterTableVC.swift; sourceTree = "<group>"; };
+		32D2F9FD24724CCF0075AF0B /* AssetFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetFilterCell.swift; path = src/Views/AssetFilterCell.swift; sourceTree = "<group>"; };
+		32D2F9FF247391A30075AF0B /* AssetFilterAdapterProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetFilterAdapterProtocol.swift; sourceTree = "<group>"; };
+		32D2FA02247392210075AF0B /* WhitelistAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhitelistAdapter.swift; sourceTree = "<group>"; };
+		32D2FA0424745F1F0075AF0B /* BlacklistAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlacklistAdapter.swift; sourceTree = "<group>"; };
 		4106E6C6220D892100C29B86 /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Fabric.framework; sourceTree = "<group>"; };
 		4106E6C7220D892100C29B86 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Crashlytics.framework; sourceTree = "<group>"; };
 		41085230216965F30027DB2A /* AddressBookFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AddressBookFooterView.swift; path = src/Views/AddressBookFooterView.swift; sourceTree = "<group>"; };
@@ -2158,6 +2172,16 @@
 			path = libbz2;
 			sourceTree = "<group>";
 		};
+		32D2FA012473920C0075AF0B /* adapters */ = {
+			isa = PBXGroup;
+			children = (
+				32D2F9FF247391A30075AF0B /* AssetFilterAdapterProtocol.swift */,
+				32D2FA02247392210075AF0B /* WhitelistAdapter.swift */,
+				32D2FA0424745F1F0075AF0B /* BlacklistAdapter.swift */,
+			);
+			path = adapters;
+			sourceTree = "<group>";
+		};
 		4106E6C5220D892100C29B86 /* Crashlytics */ = {
 			isa = PBXGroup;
 			children = (
@@ -2215,11 +2239,13 @@
 		41358D032175DDB500B86443 /* Assets */ = {
 			isa = PBXGroup;
 			children = (
+				32D2FA012473920C0075AF0B /* adapters */,
 				41EA80DC217B751F00B67A78 /* AllAssetVC.swift */,
 				41EA80DB217B751E00B67A78 /* AllAssetTableVC.swift */,
 				41358D042175DDB500B86443 /* ManageAssetDisplayVC.swift */,
 				41358D1C21761BD800B86443 /* ManageAssetTableVC.swift */,
 				41B6061A217BC6840050DB58 /* FeeAmountVC.swift */,
+				32D2F9FB24723FA60075AF0B /* AssetFilterTableVC.swift */,
 			);
 			name = Assets;
 			path = src/ViewControllers/Assets;
@@ -3218,6 +3244,8 @@
 				CEEC70871E943DC900EF788E /* TouchIdEnabledTests.swift */,
 				CEEC70971E96BF8800EF788E /* DefaultCurrencyTests.swift */,
 				41FB22452211F0AC00C072A5 /* TransferAssetTest.swift */,
+				326F8C252471A87A005D91EA /* CoreDatabaseTest.swift */,
+				32D2F9F924721CC30075AF0B /* AssetManagerTest.swift */,
 			);
 			path = ravenwalletTests;
 			sourceTree = "<group>";
@@ -3591,6 +3619,7 @@
 				412CAB5421EFBA26000C393D /* AllAddressesListCell.swift */,
 				41743A1D2174B4BA00624970 /* AssetHomeCell.swift */,
 				41358D1E2176288B00B86443 /* AssetManageCell.swift */,
+				32D2F9FD24724CCF0075AF0B /* AssetFilterCell.swift */,
 				CE6BCF5C1EE9E89A0029849C /* CustomTitleView.swift */,
 				CED341321EF5A5C00014912A /* InAppAlert.swift */,
 				411281CF217DD29F002A6205 /* AssetCell */,
@@ -4619,6 +4648,7 @@
 				413204FA21D9622A006ADCAE /* NameAssetCell.swift in Sources */,
 				419BD11621B6DDE60070B2C8 /* AAOptionsConstructor.swift in Sources */,
 				CEC6AA3B1DEE4EB000EE5AFD /* CGRect+Additions.swift in Sources */,
+				32D2FA03247392210075AF0B /* WhitelistAdapter.swift in Sources */,
 				7C5AC8A6203B93D3001B221E /* TxListCell.swift in Sources */,
 				1042439F2405592900FF8DDF /* AAColor.swift in Sources */,
 				CEE659E71F65A936001FF29D /* RetryTimer.swift in Sources */,
@@ -4669,6 +4699,7 @@
 				410C3EC721933972002B5208 /* TermsUseBtnCell.swift in Sources */,
 				CEA05CC31F21B53C00D850F0 /* FeeSelector.swift in Sources */,
 				417C680F216B51E10090710E /* AddressBookListCell.swift in Sources */,
+				32D2F9FC24723FA70075AF0B /* AssetFilterTableVC.swift in Sources */,
 				CE20C8F21DBAF71500C8397A /* ApplicationController.swift in Sources */,
 				CEC4CF071F0C48DD00E5C82E /* StartWipeWalletViewController.swift in Sources */,
 				41743A202174BCE400624970 /* WalletListViewModel.swift in Sources */,
@@ -4698,6 +4729,7 @@
 				CE44BA1B1F33BFC500392A1A /* NodeSelectorViewController.swift in Sources */,
 				CE36454A1E7B426B0079D0CF /* ClearNumberPad.swift in Sources */,
 				CE124D001E69170900DFA146 /* SyncingView.swift in Sources */,
+				32D2FA00247391A30075AF0B /* AssetFilterAdapterProtocol.swift in Sources */,
 				CE20C90E1DBE52B000C8397A /* UIView+BRWAdditions.swift in Sources */,
 				411DF576216F59D70003A8BA /* Checkbox.swift in Sources */,
 				8B12807420FFB501002A139F /* Circle.swift in Sources */,
@@ -4847,6 +4879,7 @@
 				22A9A9561DF61945000F0016 /* BRWalletPlugin.swift in Sources */,
 				4CD96FDA243F8EA900F0DC46 /* keccakf1600.c in Sources */,
 				CE6B829A1FE3A7B6007A41B9 /* UIScrollView+Additions.swift in Sources */,
+				32D2F9FE24724CCF0075AF0B /* AssetFilterCell.swift in Sources */,
 				8B137EB320F90F63006DEB3A /* sha256.cpp in Sources */,
 				CEF3E8361DE60222007C0A9E /* ModalNavigationController.swift in Sources */,
 				CED811E21EB302DD003A8D1E /* WatchTransaction.swift in Sources */,
@@ -4902,6 +4935,7 @@
 				41358D072175DDB500B86443 /* ManageAssetDisplayVC.swift in Sources */,
 				CE20C90C1DBC59E600C8397A /* StartFlowPresenter.swift in Sources */,
 				CE20C8FC1DBB0F3A00C8397A /* UIColor+BRWAdditions.swift in Sources */,
+				32D2FA0524745F1F0075AF0B /* BlacklistAdapter.swift in Sources */,
 				CEA3626A1E01150D0061FC0E /* CGContext+Additions.swift in Sources */,
 				7C6ACCB41FEB34470028ABFA /* TxLabelCell.swift in Sources */,
 				7C35E71B200AF8170064808F /* RvnTransaction.swift in Sources */,
@@ -4947,10 +4981,12 @@
 			files = (
 				22C4312E1DF89D970017CAEA /* BRHTTPServerTests.swift in Sources */,
 				CE6DCC2B1E63D6290044257B /* WalletCreationTests.swift in Sources */,
+				32D2F9FA24721CC30075AF0B /* AssetManagerTest.swift in Sources */,
 				CEC6F8471E8878B6000795B8 /* PaymentRequestTests.swift in Sources */,
 				22C431361DF8A6DF0017CAEA /* BRAPIClientTests.swift in Sources */,
 				CEDD8F101E575DD4007A4123 /* WalletAuthenticationTests.swift in Sources */,
 				CEF3D2D71E8AB9980070178E /* SpendingLimitTests.swift in Sources */,
+				326F8C262471A87A005D91EA /* CoreDatabaseTest.swift in Sources */,
 				22C431321DF89DDC0017CAEA /* NSDataExtensionTests.swift in Sources */,
 				CE6DCC291E63D0280044257B /* PhraseTests.swift in Sources */,
 				CEEC70881E943DC900EF788E /* TouchIdEnabledTests.swift in Sources */,

--- a/ravenwallet/src/Constants/Strings.swift
+++ b/ravenwallet/src/Constants/Strings.swift
@@ -243,6 +243,7 @@ enum S {
         static let confirmButton = NSLocalizedString("TermsOfUse.confirmButton", value:"Confirm & Finish", comment: "Share via email button label")
     }
     
+    //MARK: Asset
     enum Asset {
         static let settingTitle = NSLocalizedString("Asset.settingTitle", value:"Asset Display Settings", comment: "Asset Display title")
         static let emptyMessage = NSLocalizedString("Asset.emptyMessage", value:"Your assets will appear here.", comment: "Empty assets list message.")
@@ -290,6 +291,14 @@ enum S {
         static let insufficientAssetFunds = NSLocalizedString("Asset.insufficientAssetFunds", value: "Insufficient Asset Funds", comment: "Insufficient asset funds error")
         static let verifyLabel = NSLocalizedString("Asset.verifyLabel", value:"Check Availabilty", comment: "Verify button label")
         static let notVerifiedName = NSLocalizedString("Asset.notVerifiedName", value:"Operation timeout: not connected to a node that accept getAssetData MSG protocol.", comment: "Not verified asset name error")
+        static let whitelist = NSLocalizedString("Asset.whitelist", value:"Whitelist", comment: "Title for selector indicating whitelist filtering")
+        static let whitelistTitle = NSLocalizedString("Asset.whitelistTitle", value:"Whitelisted Assets", comment: "Title for section displaying assets that are included in the asset whitelist")
+        static let whitelistEmpty = NSLocalizedString("Asset.whitelistEmpty", value:"No assets in whitelist", comment: "Message letting the user know that their asset whitelist is empty")
+        static let blacklist = NSLocalizedString("Asset.blacklist", value:"Blacklist", comment: "Title for selector indicating blacklist filtering")
+        static let blacklistTitle = NSLocalizedString("Asset.blacklistTitle", value:"Blacklisted Assets", comment: "Title for section displaying assets that are included in the asset blacklist")
+        static let blacklistEmpty = NSLocalizedString("Asset.blacklistEmpty", value:"No assets in blacklist", comment: "Message letting the user know that their asset blacklist is empty")
+        static let availableAssets = NSLocalizedString("Asset.availableAssets", value:"Available Assets", comment: "Message letting the user know what assets are available for adding to a whitelist/blacklist")
+        static let none = NSLocalizedString("Asset.none", value:"None", comment: "Message letting the user know there are no assets left")
 
     }
     

--- a/ravenwallet/src/Extensions/UserDefaults+Additions.swift
+++ b/ravenwallet/src/Extensions/UserDefaults+Additions.swift
@@ -322,3 +322,19 @@ extension UserDefaults {
         defaults.set(date, forKey: shouldReloadChartKey)
     }
 }
+
+//MARK: - Asset Data
+extension UserDefaults {
+    
+    static var assetFilter: AssetManager.AssetFilter? {
+        get {
+            guard let filterString = defaults.string(forKey: "assetFilter") else { return nil }
+            
+            return AssetManager.AssetFilter(rawValue: filterString)
+        }
+        set {
+            let value = newValue?.rawValue
+            defaults.set(value, forKey: "assetFilter")
+        }
+    }
+}

--- a/ravenwallet/src/Models/Asset/AssetManager.swift
+++ b/ravenwallet/src/Models/Asset/AssetManager.swift
@@ -12,28 +12,100 @@ import SystemConfiguration
 
 class AssetManager {
     
-    static let shared = AssetManager()
-
-    var db: CoreDatabase?
-    var assetList:[Asset] = []
-    var showedAssetList:[Asset] {
-        get {
-            return assetList.filter({ $0.isHidden == false})
+    enum AssetFilter: String, CaseIterable {
+        case whitelist
+        case blacklist
+        
+        var displayString: String {
+            switch self {
+            case .whitelist: return S.Asset.whitelist
+            case .blacklist: return S.Asset.blacklist
+            }
         }
     }
     
+    static let shared = AssetManager()
+
+    private var db: CoreDatabase?
+    
+    var assetList:[Asset] = []
+    var showedAssetList:[Asset] {
+        get {
+            switch assetFilter {
+                
+            case .whitelist:
+                return assetList.filter {
+                    whitelist.contains($0.name)
+                }
+                
+            case .blacklist:
+                return assetList.filter {
+                    !blacklist.contains($0.name)
+                }
+            }
+        }
+    }
+    
+    var assetFilter: AssetFilter {
+        didSet {
+            UserDefaults.assetFilter = assetFilter
+        }
+    }
+    
+    private(set) var whitelist: Set<String> = []
+    private(set) var blacklist: Set<String> = []
+    
     private init() {
         db = CoreDatabase()
-        loadAsset()
+        
+        // From settings, restore the filter previously used
+        if let filterFromSettings = UserDefaults.assetFilter {
+            assetFilter = filterFromSettings
+            loadAsset()
+            loadWhitelist()
+            loadBlacklist()
+        }else {
+            
+            // If there is no previous filter then we will blacklist any previously hidden assets
+            // as a blacklist is analogous to the previous hide/display by paradigm
+            assetFilter = .blacklist
+            UserDefaults.assetFilter = .blacklist // Need to manually do this as 'didSet' is not called during initialization
+            
+            loadAssetsBlocking()
+            loadBlacklist()
+            
+            assetList.filter { $0.isHidden }.forEach { self.addToBlacklist(assetName: $0.name )}
+            
+            self.loadWhitelist()
+        }
+    }
+    
+    private func loadAssetsBlocking() {
+        guard let assets = db?.blockingLoadAssets() else { return }
+        assetList = assets
+    }
+    
+    private func loadWhitelist() {
+        guard let dbWhitelist = db?.loadWhitelistBlocking() else { return }
+        
+        for asset in dbWhitelist {
+            whitelist.insert(asset)
+        }
+    }
+    
+    private func loadBlacklist() {
+        guard let dbBlacklist = db?.loadBlacklistBlocking() else { return }
+        
+        for asset in dbBlacklist {
+            blacklist.insert(asset)
+        }
     }
     
     func loadAsset(callBack: (([Asset]) -> Void)? = nil) {
-        db = CoreDatabase()
         db?.loadAssets(callback: { assets in
             self.assetList = assets
-            if callBack != nil {
-                callBack!(assets)
-            }
+            
+            callBack?(assets)
         })
     }
     
@@ -55,5 +127,64 @@ class AssetManager {
             callback(assetName, isExiste)
         })
     }
-
+    
+    //MARK: Asset Filter
+    
+    func setAssetFilter(_ assetFilter: AssetFilter) {
+        self.assetFilter = assetFilter
+    }
+    
+    //MARK: Asset Filter - Whitelist
+    
+    func addToWhitelist(assetName: String) {
+        let result = whitelist.insert(assetName)
+        
+        guard result.0 else { return } // Check that the name was inserted
+        
+        db?.addToWhitelist(assetName: assetName) { [weak self] success in
+            
+            // Reload the whitelist if the transaction is not successful so that we stay in coordination with the db
+            if !success {
+                self?.loadWhitelist()
+            }
+        }
+    }
+    
+    func removeFromWhitelist(assetName: String) {
+        guard let _ = whitelist.remove(assetName) else { return }
+            
+        db?.removeFromWhitelist(assetName: assetName)
+    }
+    
+    func clearWhitelist() {
+        whitelist.removeAll()
+        db?.clearWhitelist()
+    }
+    
+    //MARK: Asset Filter - Blacklist
+    
+    func addToBlacklist(assetName: String) {
+        let result = blacklist.insert(assetName)
+        
+        guard result.0 else { return } // Check that the name was inserted
+        
+        db?.addToBlacklist(assetName: assetName) { [weak self] success in
+            
+            // Reload the whitelist if the transaction is not successful so that we stay in coordination with the db
+            if !success {
+                self?.loadBlacklist()
+            }
+        }
+    }
+    
+    func removeFromBlacklist(assetName: String) {
+        guard let _ = blacklist.remove(assetName) else { return }
+            
+        db?.removeFromBlacklist(assetName: assetName)
+    }
+    
+    func clearBlacklist() {
+        blacklist.removeAll()
+        db?.clearBlacklist()
+    }
 }

--- a/ravenwallet/src/ViewControllers/Assets/AssetFilterTableVC.swift
+++ b/ravenwallet/src/ViewControllers/Assets/AssetFilterTableVC.swift
@@ -1,0 +1,205 @@
+//
+//  AssetFilterTableVC.swift
+//  Ravencoin
+//
+//  Created by Austin Hill on 5/17/20.
+//  Copyright © 2020 Medici Ventures. All rights reserved.
+//
+
+import UIKit
+
+class AssetFilterTableVC: UITableViewController {
+    
+    enum Section: Int, CaseIterable {
+        case inList = 0
+        case excludedFromList = 1
+        
+        init?(for indexPath: IndexPath) {
+            if let section = Section(rawValue: indexPath.section) {
+                self = section
+            }else {
+                return nil
+            }
+        }
+        
+        var footerHeight: CGFloat {
+            return 40
+        }
+    }
+    
+    internal var adapter: AssetFilterAdapterProtocol! {
+        didSet {
+            tableView.reloadData()
+        }
+    }
+    
+    private let emptyMessage = UILabel.wrapping(font: .customBody(size: 16.0), color: .grayTextTint)
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        tableView.register(AssetFilterCell.self, forCellReuseIdentifier: AssetFilterCell.reuseIdentifier)
+
+        tableView.separatorStyle = .none
+        tableView.estimatedRowHeight = 60.0
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .whiteTint
+        tableView.isEditing = true
+
+        emptyMessage.textAlignment = .center
+        emptyMessage.text = S.Asset.emptyMessage
+        
+        tableView.setEditing(false, animated: false)
+        
+        setContentInset()
+    }
+}
+
+// MARK: - Styling
+extension AssetFilterTableVC {
+    
+    private func setContentInset() {
+        let insets = UIEdgeInsets(top: manageAssetHeaderHeight - 64.0 - (E.isIPhoneXOrLater ? 28.0 : 0.0), left: 0, bottom: C.padding[2], right: 0)
+        tableView.contentInset = insets
+        tableView.scrollIndicatorInsets = insets
+    }
+    
+    private func getFooter(for section: Section) -> UIView? {
+        let footerText: String
+        
+        switch section {
+        case .inList:
+            guard adapter.includedList.count == 0 else { return nil }
+            footerText = adapter.emptyListText()
+        case .excludedFromList:
+            guard adapter.excludedList.count == 0 else { return nil }
+            footerText = S.Asset.emptyMessage
+        }
+        
+        let footerView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: section.footerHeight))
+        footerView.backgroundColor = UIColor.white
+        
+        let emptyMessage = UILabel.wrapping(font: .customBody(size: 16.0), color: .grayTextTint)
+        footerView.addSubview(emptyMessage)
+        emptyMessage.text = footerText
+        emptyMessage.textAlignment = .center
+        
+        emptyMessage.constrain([
+            emptyMessage.centerXAnchor.constraint(equalTo: footerView.centerXAnchor),
+            emptyMessage.centerYAnchor.constraint(equalTo: footerView.centerYAnchor),
+            emptyMessage.widthAnchor.constraint(equalTo: footerView.widthAnchor, constant: -C.padding[2]) ])
+        
+        return footerView
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        guard let section = Section(rawValue: section) else { return nil }
+        
+        switch section {
+        case .inList:
+            return adapter.titleForList()
+            
+        case .excludedFromList:
+            return S.Asset.availableAssets
+        }
+    }
+    
+    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        guard let section = Section(rawValue: section) else { return nil }
+        
+        return getFooter(for: section)
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        guard let section = Section(rawValue: section) else { return 0 }
+        
+        return getFooter(for: section)?.bounds.height ?? 0.0
+    }
+}
+
+// MARK: - Data source
+extension AssetFilterTableVC {
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return Section.allCases.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    
+        guard let section = Section(rawValue: section) else { return 0 }
+        
+        switch section {
+        case .inList:
+            return adapter.includedList.count
+            
+        case .excludedFromList:
+            return adapter.excludedList.count
+        }
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: AssetFilterCell.reuseIdentifier, for: indexPath) as! AssetFilterCell
+        
+        guard let section = Section(for: indexPath) else { return cell }
+        
+        let assetName: String
+        
+        switch section {
+        case .inList:
+            assetName = adapter.includedList[indexPath.row]
+            
+        case .excludedFromList:
+            assetName = adapter.excludedList[indexPath.row]
+        }
+        
+        cell.assetName = assetName
+        return cell
+    }
+}
+
+// MARK: - Interaction
+extension AssetFilterTableVC {
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let section = Section(for: indexPath) else { return }
+        
+        switch section {
+        case .inList:
+
+            let assetName = adapter.includedList[indexPath.row]
+            adapter.removeFromList(assetName)
+            tableView.reloadData()
+            
+        case .excludedFromList:
+            let assetName = adapter.excludedList[indexPath.row]
+            adapter.addToList(assetName)
+            tableView.reloadData()
+        }
+    }
+    
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        guard let section = Section(for: indexPath) else { return false}
+        switch section {
+        case .inList: return true
+        case .excludedFromList: return false
+        }
+    }
+
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        guard let section = Section(for: indexPath) else { return }
+        
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            if section == .inList {
+                adapter.removeFromList(adapter.includedList[indexPath.row])
+                tableView.deleteRows(at: [indexPath], with: .fade)
+            }
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }
+    }
+}

--- a/ravenwallet/src/ViewControllers/Assets/ManageAssetDisplayVC.swift
+++ b/ravenwallet/src/ViewControllers/Assets/ManageAssetDisplayVC.swift
@@ -13,21 +13,24 @@ import MachO
 let manageAssetHeaderHeight: CGFloat = E.isIPhoneXOrLater ? 90 : 67.0
 
 class ManageAssetDisplayVC : UIViewController, Subscriber {
-
-    //MARK: - Public
-    
-    init() {
-        self.headerView = ManageAssetHeaderView(title: S.Asset.settingTitle)
-        super.init(nibName: nil, bundle: nil)
-        self.manageAssetTableVC = ManageAssetTableVC()
-    }
     
     //MARK: - Private
     private let headerView: ManageAssetHeaderView
     private let transitionDelegate = ModalTransitionDelegate(type: .transactionDetail)
-    private var manageAssetTableVC: ManageAssetTableVC!
+    private var assetFilterListVC: AssetFilterTableVC!
     private var isLoginRequired = false
     private let headerContainer = UIView()
+    
+    private let filters: [AssetManager.AssetFilter] = [
+        .blacklist,
+        .whitelist
+    ]
+    private let filterSelectorView = UIView()
+    private let filterSelectorControl: UISegmentedControl
+    
+    private let whitelistAdapter: WhitelistAdapter
+    private let blacklistAdapter: BlacklistAdapter
+    
     private var shouldShowStatusBar: Bool = true {
         didSet {
             if oldValue != shouldShowStatusBar {
@@ -37,56 +40,90 @@ class ManageAssetDisplayVC : UIViewController, Subscriber {
             }
         }
     }
+    
+    init() {
+        self.headerView = ManageAssetHeaderView(title: S.Asset.settingTitle)
+        self.assetFilterListVC = AssetFilterTableVC()
+        self.whitelistAdapter = WhitelistAdapter(assetManager: AssetManager.shared)
+        self.blacklistAdapter = BlacklistAdapter(assetManager: AssetManager.shared)
+        
+        // Filter setup
+        self.filterSelectorControl = UISegmentedControl(items: filters.map({$0.displayString}))
+        
+        super.init(nibName: nil, bundle: nil)
+        
+        let assetFilter = AssetManager.shared.assetFilter
+        filterSelectorControl.selectedSegmentIndex = filters.firstIndex(of: assetFilter)!
+        filterSelectorControl.valueChanged = filterSelectorDidChange
+        showFilterList(assetFilter)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+//MARK: - UIViewController
+extension ManageAssetDisplayVC {
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupNavigationBar()
-        addManageAssetView()
+        
         addSubviews()
-        addConstraints()
-        setInitialData()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         shouldShowStatusBar = true
     }
+}
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-    }
+//MARK: - View Setup
+extension ManageAssetDisplayVC {
     
-    // MARK: -
-    
-    private func setupNavigationBar() {
-        
-    }
-
     private func addSubviews() {
-        view.addSubview(headerContainer)
-        headerContainer.addSubview(headerView)
-    }
-
-    private func addConstraints() {
-        headerContainer.constrainTopCorners(height: manageAssetHeaderHeight)
-        headerView.constrain(toSuperviewEdges: nil)
-    }
-
-    private func setInitialData() {
-
-    }
-
-    private func addManageAssetView() {
+        
+        // Style
         view.backgroundColor = .whiteTint
-        addChild(manageAssetTableVC, layout: {
+        
+        // Header container
+        view.addSubview(headerContainer)
+        headerContainer.constrainTopCorners(height: manageAssetHeaderHeight)
+        
+        // Header
+        headerContainer.addSubview(headerView)
+        headerView.constrain(toSuperviewEdges: nil)
+        
+        // Selector container
+        view.addSubview(filterSelectorView)
+        filterSelectorView.constrain([
+            filterSelectorView.topAnchor.constraint(equalTo: headerContainer.bottomAnchor),
+            filterSelectorView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor),
+            filterSelectorView.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor),
+            filterSelectorView.heightAnchor.constraint(equalToConstant: 40.0)
+        ])
+        
+        // Selector
+        filterSelectorView.addSubview(filterSelectorControl)
+        filterSelectorControl.constrain([
+            filterSelectorControl.rightAnchor.constraint(equalTo: filterSelectorView.rightAnchor, constant: -C.padding[1]),
+            filterSelectorControl.centerYAnchor.constraint(equalTo: filterSelectorView.centerYAnchor),
+            filterSelectorControl.leftAnchor.constraint(equalTo: filterSelectorView.leftAnchor, constant: C.padding[1]),
+            filterSelectorControl.topAnchor.constraint(equalTo: filterSelectorView.topAnchor, constant: C.padding[1]),
+            filterSelectorControl.bottomAnchor.constraint(equalTo: filterSelectorView.bottomAnchor, constant: -C.padding[1])
+            
+        ])
+        
+        // Filter list view controller
+        addChild(assetFilterListVC, layout: {
             if #available(iOS 11.0, *) {
-                manageAssetTableVC.view.constrain([
-                    manageAssetTableVC.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-                manageAssetTableVC.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-                manageAssetTableVC.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-                manageAssetTableVC.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+                assetFilterListVC.view.constrain([
+                assetFilterListVC.view.topAnchor.constraint(equalTo: filterSelectorView.bottomAnchor),
+                assetFilterListVC.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+                assetFilterListVC.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                assetFilterListVC.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
                 ])
             } else {
-                manageAssetTableVC.view.constrain(toSuperviewEdges: nil)
+                assetFilterListVC.view.constrain(toSuperviewEdges: nil)
             }
         })
     }
@@ -102,8 +139,26 @@ class ManageAssetDisplayVC : UIViewController, Subscriber {
     override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
         return .slide
     }
+    
+    private func showFilterList(_ filter: AssetManager.AssetFilter) {
+        switch filter {
+        case .whitelist:
+            self.assetFilterListVC.adapter = self.whitelistAdapter
+        case .blacklist:
+            self.assetFilterListVC.adapter = self.blacklistAdapter
+        }
+    }
+}
 
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+//MARK: - Handlers
+extension ManageAssetDisplayVC {
+    func filterSelectorDidChange() {
+        
+        let index = filterSelectorControl.selectedSegmentIndex
+        let filter = filters[index]
+        
+        AssetManager.shared.setAssetFilter(filter)
+        
+        showFilterList(filter)
     }
 }

--- a/ravenwallet/src/ViewControllers/Assets/adapters/AssetFilterAdapterProtocol.swift
+++ b/ravenwallet/src/ViewControllers/Assets/adapters/AssetFilterAdapterProtocol.swift
@@ -1,0 +1,20 @@
+//
+//  AssetFilterAdapterProtocol.swift
+//  Ravencoin
+//
+//  Created by Austin Hill on 5/18/20.
+//  Copyright © 2020 Medici Ventures. All rights reserved.
+//
+
+import Foundation
+
+protocol AssetFilterAdapterProtocol {
+    
+    var includedList: [String] {get}
+    var excludedList: [String] {get}
+    
+    func addToList(_ assetName: String)
+    func removeFromList(_ assetName: String)
+    func titleForList() -> String
+    func emptyListText() -> String
+}

--- a/ravenwallet/src/ViewControllers/Assets/adapters/BlacklistAdapter.swift
+++ b/ravenwallet/src/ViewControllers/Assets/adapters/BlacklistAdapter.swift
@@ -1,0 +1,50 @@
+//
+//  BlacklistAdapter.swift
+//  Ravencoin
+//
+//  Created by Austin Hill on 5/19/20.
+//  Copyright © 2020 Medici Ventures. All rights reserved.
+//
+
+import Foundation
+
+class BlacklistAdapter: AssetFilterAdapterProtocol {
+    
+    private var assetManager: AssetManager
+    
+    var includedList: [String] = []
+    var excludedList: [String] = []
+    
+    init(assetManager: AssetManager) {
+        self.assetManager = assetManager
+        
+        updateLists()
+    }
+    
+    private func updateLists() {
+        includedList = assetManager.blacklist.sorted()
+        
+        excludedList = assetManager.assetList
+            .map {$0.name}
+            .filter {!assetManager.blacklist.contains($0)}
+            .sorted()
+    }
+    
+    func addToList(_ assetName: String) {
+        assetManager.addToBlacklist(assetName: assetName)
+        updateLists()
+    }
+    
+    func removeFromList(_ assetName: String) {
+        assetManager.removeFromBlacklist(assetName: assetName)
+        updateLists()
+    }
+    
+    func titleForList() -> String {
+        S.Asset.blacklistTitle
+    }
+    
+    func emptyListText() -> String {
+        S.Asset.blacklistEmpty
+    }
+}

--- a/ravenwallet/src/ViewControllers/Assets/adapters/WhitelistAdapter.swift
+++ b/ravenwallet/src/ViewControllers/Assets/adapters/WhitelistAdapter.swift
@@ -1,0 +1,50 @@
+//
+//  WhitelistAdapter.swift
+//  Ravencoin
+//
+//  Created by Austin Hill on 5/18/20.
+//  Copyright © 2020 Medici Ventures. All rights reserved.
+//
+
+import Foundation
+
+class WhitelistAdapter: AssetFilterAdapterProtocol {
+    
+    private var assetManager: AssetManager
+    
+    var includedList: [String] = []
+    var excludedList: [String] = []
+    
+    init(assetManager: AssetManager) {
+        self.assetManager = assetManager
+        
+        updateLists()
+    }
+    
+    private func updateLists() {
+        includedList = assetManager.whitelist.sorted()
+        
+        excludedList = assetManager.assetList
+            .map {$0.name}
+            .filter {!assetManager.whitelist.contains($0)}
+            .sorted()
+    }
+    
+    func addToList(_ assetName: String) {
+        assetManager.addToWhitelist(assetName: assetName)
+        updateLists()
+    }
+    
+    func removeFromList(_ assetName: String) {
+        assetManager.removeFromWhitelist(assetName: assetName)
+        updateLists()
+    }
+    
+    func titleForList() -> String {
+        S.Asset.whitelistTitle
+    }
+    
+    func emptyListText() -> String {
+        S.Asset.whitelistEmpty
+    }
+}

--- a/ravenwallet/src/Views/AssetFilterCell.swift
+++ b/ravenwallet/src/Views/AssetFilterCell.swift
@@ -1,0 +1,25 @@
+//
+//  AssetFilterCell.swift
+//  Ravencoin
+//
+//  Created by Austin Hill on 5/17/20.
+//  Copyright © 2020 Medici Ventures. All rights reserved.
+//
+
+import UIKit
+
+class AssetFilterCell: UITableViewCell {
+    static var reuseIdentifier = "assetFilterCell"
+    
+    var assetName: String? {
+        didSet {
+            guard let assetName = assetName else { return }
+            self.textLabel?.text = assetName
+        }
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+}

--- a/ravenwalletTests/AssetManagerTest.swift
+++ b/ravenwalletTests/AssetManagerTest.swift
@@ -1,0 +1,128 @@
+//
+//  AssetManagerTest.swift
+//  RavencoinTests
+//
+//  Created by Austin Hill on 5/17/20.
+//  Copyright © 2020 Medici Ventures. All rights reserved.
+//
+
+@testable import Ravencoin
+import XCTest
+
+class AssetManagerTest: XCTestCase {
+
+    var assetManager: AssetManager!
+    
+    override func setUpWithError() throws {
+        assetManager = AssetManager.shared
+        assetManager.assetList.removeAll()
+        assetManager.clearWhitelist()
+        assetManager.clearBlacklist()
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        assetManager.assetList.removeAll()
+        assetManager.clearWhitelist()
+        assetManager.clearBlacklist()
+        assetManager = nil
+        try super.tearDownWithError()
+    }
+    
+    func testWhitelist() throws {
+        XCTAssertEqual(assetManager.assetList.count, 0, "Starting whitelist should be empty")
+        
+        let testAssets = ["test", "test1", "test2"]
+        for (index, assetname) in testAssets.enumerated() {
+            let asset = Asset(idAsset: index, name: assetname, amount: Satoshis(rawValue: 100), units: 1, reissubale: 0, hasIpfs: 0, ipfsHash: "", ownerShip: 0, hidden: 0, sort: 0)
+            assetManager.assetList.append(asset)
+        }
+        
+        assetManager.setAssetFilter(.whitelist)
+        XCTAssertEqual(assetManager.assetList.count, testAssets.count, "Newly added assets should be only assets in manager")
+        XCTAssertEqual(assetManager.showedAssetList.count, 0, "All assets should be hidden")
+        
+        // Add test assets to whitelist
+        var shownAssets = 0
+        for assetName in testAssets {
+            assetManager.addToWhitelist(assetName: assetName)
+            shownAssets += 1
+            
+            XCTAssertEqual(assetManager.assetList.count, testAssets.count, "All assets should still exist")
+            XCTAssertEqual(assetManager.showedAssetList.count, shownAssets, "Should be one more visible asset than previous")
+            XCTAssertNotNil(assetManager.showedAssetList.first(where: {$0.name == assetName}), "Asset with the current asset name should be visible")
+        }
+        
+        XCTAssertEqual(assetManager.showedAssetList.count, testAssets.count, "All assets have been added to the whitelist and should be visible")
+        
+        // Remove test assets from whitelist
+        for assetName in testAssets {
+            assetManager.removeFromWhitelist(assetName: assetName)
+            shownAssets -= 1
+            
+            XCTAssertEqual(assetManager.assetList.count, testAssets.count, "All assets should still exist")
+            XCTAssertEqual(assetManager.showedAssetList.count, shownAssets, "Should be one less visible asset than previous")
+            XCTAssertNil(assetManager.showedAssetList.first(where: {$0.name == assetName}), "Asset with the current asset name should be hidden")
+        }
+        
+        XCTAssertEqual(assetManager.showedAssetList.count, 0, "All assets have been removed from the whitelist and should be hidden")
+    }
+    
+    func testBlacklist() throws {
+        XCTAssertEqual(assetManager.assetList.count, 0, "Starting whitelist should be empty")
+        
+        let testAssets = ["test", "test1", "test2"]
+        for (index, assetname) in testAssets.enumerated() {
+            let asset = Asset(idAsset: index, name: assetname, amount: Satoshis(rawValue: 100), units: 1, reissubale: 0, hasIpfs: 0, ipfsHash: "", ownerShip: 0, hidden: 0, sort: 0)
+            assetManager.assetList.append(asset)
+        }
+        
+        assetManager.setAssetFilter(.blacklist)
+        XCTAssertEqual(assetManager.assetList.count, testAssets.count, "Newly added assets should be only assets in manager")
+        XCTAssertEqual(assetManager.showedAssetList.count, testAssets.count, "All assets should be visible")
+        
+        // Add test assets to blacklist
+        var shownAssets = testAssets.count
+        for assetName in testAssets {
+            assetManager.addToBlacklist(assetName: assetName)
+            shownAssets -= 1
+            
+            XCTAssertEqual(assetManager.assetList.count, testAssets.count, "All assets should still exist")
+            XCTAssertEqual(assetManager.showedAssetList.count, shownAssets, "Should be one less visible asset than previous")
+            XCTAssertNil(assetManager.showedAssetList.first(where: {$0.name == assetName}), "Asset with the current asset name should be hidden")
+        }
+        
+        XCTAssertEqual(assetManager.showedAssetList.count, 0, "All assets have been added to the blacklist and should be hidden")
+        
+        // Remove test assets from blacklist
+        for assetName in testAssets {
+            assetManager.removeFromBlacklist(assetName: assetName)
+            shownAssets += 1
+            
+            XCTAssertEqual(assetManager.assetList.count, testAssets.count, "All assets should still exist")
+            XCTAssertEqual(assetManager.showedAssetList.count, shownAssets, "Should be one more visible asset than previous")
+            XCTAssertNotNil(assetManager.showedAssetList.first(where: {$0.name == assetName}), "Asset with the current asset name should be visible")
+        }
+        
+        XCTAssertEqual(assetManager.showedAssetList.count, testAssets.count, "All assets have been removed from the blacklist and should be visible")
+    }
+    
+    func testSwitchFilters() throws {
+        XCTAssertEqual(assetManager.assetList.count, 0, "Starting whitelist should be empty")
+        
+        let testAssets = ["test", "test1", "test2"]
+        for (index, assetname) in testAssets.enumerated() {
+            let asset = Asset(idAsset: index, name: assetname, amount: Satoshis(rawValue: 100), units: 1, reissubale: 0, hasIpfs: 0, ipfsHash: "", ownerShip: 0, hidden: 0, sort: 0)
+            assetManager.assetList.append(asset)
+        }
+        
+        XCTAssertEqual(assetManager.assetList.count, testAssets.count, "Newly added assets should be only assets in manager")
+        
+        assetManager.setAssetFilter(.whitelist)
+        XCTAssertEqual(assetManager.showedAssetList.count, 0, "Whitelist is empty, all assets should be hidden")
+        
+        assetManager.setAssetFilter(.blacklist)
+        XCTAssertEqual(assetManager.showedAssetList.count, testAssets.count, "Blacklist is empty, all assets should be visible")
+    }
+}

--- a/ravenwalletTests/CoreDatabaseTest.swift
+++ b/ravenwalletTests/CoreDatabaseTest.swift
@@ -1,0 +1,206 @@
+//
+//  AssetManagerTest.swift
+//  RavencoinTests
+//
+//  Created by Austin Hill on 5/17/20.
+//  Copyright © 2020 Medici Ventures. All rights reserved.
+//
+
+import XCTest
+import Foundation
+
+@testable import Ravencoin
+
+class CoreDatabaseTest: XCTestCase {
+    
+    var db: CoreDatabase!
+    let dbLock = DispatchSemaphore(value: 1)
+
+    override func setUpWithError() throws {
+        db = CoreDatabase()
+        
+        dbLock.wait()
+        db.clearBlacklist {
+            self.dbLock.signal()
+        }
+        
+        dbLock.wait()
+        db.clearWhitelist {
+            self.dbLock.signal()
+        }
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        db.close()
+        db = nil
+    }
+
+    func testDbWhitelist() throws {
+        let loadExpectation = self.expectation(description: "Load empty whitelist")
+        dbLock.wait()
+        db.loadWhitelist { whitelist in
+            XCTAssertEqual(whitelist.count, 0, "whitelist should be empty")
+            self.dbLock.signal()
+            loadExpectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0)
+        
+        var whitelist = ["Test", "Test2", "Test3"]
+        for asset in whitelist {
+            dbLock.wait()
+            db.addToWhitelist(assetName: asset) { _ in
+                self.dbLock.signal()
+            }
+        }
+        
+        let reloadExpectation = self.expectation(description: "Load populated whitelist")
+        dbLock.wait()
+        db.loadWhitelist { returnList in
+            XCTAssertEqual(returnList.count, whitelist.count, "whitelist should have \(whitelist.count) values")
+            let sortedReturnList = returnList.sorted()
+            whitelist.sort()
+            
+            for (index, value) in whitelist.enumerated() {
+                XCTAssertEqual(value, sortedReturnList[index])
+            }
+            self.dbLock.signal()
+            reloadExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+        
+        
+        let noRemoveExpectation = self.expectation(description: "Wait for removal operation")
+        dbLock.wait()
+        db.addToWhitelist(assetName: "Test3") { success in
+            XCTAssertFalse(success, "Duplicate assets should not be added")
+            self.dbLock.signal()
+            noRemoveExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+        
+        let recountExpectation = self.expectation(description: "Load whitelist again to see if there are changes")
+        dbLock.wait()
+        db.loadWhitelist { returnList in
+            XCTAssertEqual(returnList.count, whitelist.count, "Last whitelist addition should not have made it into the db")
+            let sortedReturnList = returnList.sorted()
+            whitelist.sort()
+            
+            for (index, value) in whitelist.enumerated() {
+                XCTAssertEqual(value, sortedReturnList[index])
+            }
+            self.dbLock.signal()
+            recountExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+        
+        let assetToRemove = "Test3"
+        whitelist.removeAll(where: {$0 == assetToRemove})
+        let removeExpectation = self.expectation(description: "Wait for removal operation")
+        dbLock.wait()
+        db.removeFromWhitelist(assetName: assetToRemove) {
+            self.dbLock.signal()
+            removeExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+        
+        let removedExpectation = self.expectation(description: "Wait for reload of whitelist")
+        dbLock.wait()
+        db.loadWhitelist { returnList in
+            XCTAssertEqual(returnList.count, whitelist.count, "Whitelist removal should have committed in the db")
+            let sortedReturnList = returnList.sorted()
+            whitelist.sort()
+            
+            for (index, value) in whitelist.enumerated() {
+                XCTAssertEqual(value, sortedReturnList[index])
+            }
+            self.dbLock.signal()
+            removedExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testDbBlacklist() throws {
+        let loadExpectation = self.expectation(description: "Load empty blacklist")
+        db.loadBlacklist { blacklist in
+            XCTAssertEqual(blacklist.count, 0, "blacklist should be empty")
+            loadExpectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0)
+        
+        var blacklist = ["Test", "Test2", "Test3"]
+        for asset in blacklist {
+            dbLock.wait()
+            db.addToBlacklist(assetName: asset) { _ in
+                self.dbLock.signal()
+            }
+        }
+        
+        let reloadExpectation = self.expectation(description: "Load populated blacklist")
+        dbLock.wait()
+        db.loadBlacklist { returnList in
+            XCTAssertEqual(returnList.count, blacklist.count, "blacklist should have \(blacklist.count) values")
+            let sortedReturnList = returnList.sorted()
+            blacklist.sort()
+            
+            for (index, value) in blacklist.enumerated() {
+                XCTAssertEqual(value, sortedReturnList[index])
+            }
+            self.dbLock.signal()
+            reloadExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+        
+        
+        let noRemoveExpectation = self.expectation(description: "Wait for removal operation")
+        dbLock.wait()
+        db.addToBlacklist(assetName: "Test3") { success in
+            XCTAssertFalse(success, "Duplicate assets should not be added")
+            self.dbLock.signal()
+            noRemoveExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+        
+        let recountExpectation = self.expectation(description: "Load blacklist again to see if there are changes")
+        dbLock.wait()
+        db.loadBlacklist { returnList in
+            XCTAssertEqual(returnList.count, blacklist.count, "Last blacklist addition should not have made it into the db")
+            let sortedReturnList = returnList.sorted()
+            blacklist.sort()
+            
+            for (index, value) in blacklist.enumerated() {
+                XCTAssertEqual(value, sortedReturnList[index])
+            }
+            self.dbLock.signal()
+            recountExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+        
+        let assetToRemove = "Test3"
+        blacklist.removeAll(where: {$0 == assetToRemove})
+        let removeExpectation = self.expectation(description: "Wait for removal operation")
+        dbLock.wait()
+        db.removeFromBlacklist(assetName: assetToRemove) {
+            self.dbLock.signal()
+            removeExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+        
+        let removedExpectation = self.expectation(description: "Wait for reload of blacklist")
+        dbLock.wait()
+        db.loadBlacklist { returnList in
+            XCTAssertEqual(returnList.count, blacklist.count, "blacklist removal should have committed in the db")
+            let sortedReturnList = returnList.sorted()
+            blacklist.sort()
+            
+            for (index, value) in blacklist.enumerated() {
+                XCTAssertEqual(value, sortedReturnList[index])
+            }
+            self.dbLock.signal()
+            removedExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+}


### PR DESCRIPTION
For #141  

From the same menu that was previously used to hide assets the user can now choose whitelist or blacklist filtering. I think the UI for adding/removing assets from the whitelist/blacklist is pretty straightforward but I welcome any feedback. Unlike before, assets that have been filtered out are also assets are hidden from the asset list AND the transaction list. This seemed logical for me, but I can change that behavior if need be. Additionally I've removed the hide/display button functionality as it is no longer necessary (it is essentially a blacklist).

## Upgrade considerations
Any assets that were previously hidden using the 'hide button' functionality will be added to the blacklist on first run, however their "hidden" property in the DB will remain unchanged as the whitelist/blacklist functionality does not use that property. This will also maintain the state of hidden/shown assets should the whitelist/blacklist functionality be reverted.

## Tests
I don't have a great way of testing different wallets with different assets, but I've added unit tests for the added "CoreDatabase" functionality as well as the new "AssetManager" functionality. I've tested upgrading my wallet with hidden assets and they do get placed on the blacklist upon upgrade.

## Future Work
It would be pretty straightforward to use this whitelist/blacklist functionality to create white labeled wallets in the future, I'm more than happy to tackle that next if someone has requirements for it!