### PR TITLE
Shows alert when whitelist is empty

### DIFF
--- a/ravenwallet/src/Constants/Strings.swift
+++ b/ravenwallet/src/Constants/Strings.swift
@@ -294,6 +294,7 @@ enum S {
         static let whitelist = NSLocalizedString("Asset.whitelist", value:"Whitelist", comment: "Title for selector indicating whitelist filtering")
         static let whitelistTitle = NSLocalizedString("Asset.whitelistTitle", value:"Whitelisted Assets", comment: "Title for section displaying assets that are included in the asset whitelist")
         static let whitelistEmpty = NSLocalizedString("Asset.whitelistEmpty", value:"No assets in whitelist", comment: "Message letting the user know that their asset whitelist is empty")
+        static let whitelistEmptyWarningMessage = NSLocalizedString("Asset.whitelistEmptyWarningMessage", value:"Leaving the whitelist empty will hide all assets", comment: "Message letting the user know that their asset whitelist is empty")
         static let blacklist = NSLocalizedString("Asset.blacklist", value:"Blacklist", comment: "Title for selector indicating blacklist filtering")
         static let blacklistTitle = NSLocalizedString("Asset.blacklistTitle", value:"Blacklisted Assets", comment: "Title for section displaying assets that are included in the asset blacklist")
         static let blacklistEmpty = NSLocalizedString("Asset.blacklistEmpty", value:"No assets in blacklist", comment: "Message letting the user know that their asset blacklist is empty")

--- a/ravenwallet/src/Models/Asset/AssetManager.swift
+++ b/ravenwallet/src/Models/Asset/AssetManager.swift
@@ -118,6 +118,7 @@ class AssetManager {
         }
     }
     
+    @available(*, deprecated, message: "Will be removed in favor of using the blacklist/whitelist functionality" )
     func hideAsset(asset:Asset, where idOldValue:Int, callback: ((Bool)->Void)? = nil) {
         db?.updateHideAsset(asset, where: idOldValue, callback: callback)
     }

--- a/ravenwallet/src/ViewControllers/Assets/adapters/AssetFilterAdapterProtocol.swift
+++ b/ravenwallet/src/ViewControllers/Assets/adapters/AssetFilterAdapterProtocol.swift
@@ -10,6 +10,8 @@ import Foundation
 
 protocol AssetFilterAdapterProtocol {
     
+    var delegate: AssetFilterAdapterDelegate? {get set}
+    
     var includedList: [String] {get}
     var excludedList: [String] {get}
     
@@ -17,4 +19,8 @@ protocol AssetFilterAdapterProtocol {
     func removeFromList(_ assetName: String)
     func titleForList() -> String
     func emptyListText() -> String
+}
+
+protocol AssetFilterAdapterDelegate {
+    func didRemoveFromList(_ adapter: AssetFilterAdapterProtocol)
 }

--- a/ravenwallet/src/ViewControllers/Assets/adapters/BlacklistAdapter.swift
+++ b/ravenwallet/src/ViewControllers/Assets/adapters/BlacklistAdapter.swift
@@ -12,6 +12,8 @@ class BlacklistAdapter: AssetFilterAdapterProtocol {
     
     private var assetManager: AssetManager
     
+    var delegate: AssetFilterAdapterDelegate?
+    
     var includedList: [String] = []
     var excludedList: [String] = []
     
@@ -38,6 +40,7 @@ class BlacklistAdapter: AssetFilterAdapterProtocol {
     func removeFromList(_ assetName: String) {
         assetManager.removeFromBlacklist(assetName: assetName)
         updateLists()
+        delegate?.didRemoveFromList(self)
     }
     
     func titleForList() -> String {

--- a/ravenwallet/src/ViewControllers/Assets/adapters/WhitelistAdapter.swift
+++ b/ravenwallet/src/ViewControllers/Assets/adapters/WhitelistAdapter.swift
@@ -12,6 +12,8 @@ class WhitelistAdapter: AssetFilterAdapterProtocol {
     
     private var assetManager: AssetManager
     
+    var delegate: AssetFilterAdapterDelegate?
+    
     var includedList: [String] = []
     var excludedList: [String] = []
     
@@ -38,6 +40,7 @@ class WhitelistAdapter: AssetFilterAdapterProtocol {
     func removeFromList(_ assetName: String) {
         assetManager.removeFromWhitelist(assetName: assetName)
         updateLists()
+        delegate?.didRemoveFromList(self)
     }
     
     func titleForList() -> String {


### PR DESCRIPTION
In response to [ongoing discussion about whitelist functionality](https://github.com/RavenProject/ravenwallet-ios/issues/141#issuecomment-634970176) I've implemented an alert to notify the user that no assets will be displayed if the asset whitelist is left empty. 
  
Initially the idea was to display the notification when the user attempts to navigate away from the asset filter settings screen. However capturing the back button press and displaying an alert would require implementing a custom back button. I feel that this solution is comparable, however I can implement a custom back button if need be.