### PR TITLE
Regex patterns for iOS wallet differ from the Desktop wallet

### DIFF
--- a/ravenwallet/src/Models/Asset/AssetValidator.swift
+++ b/ravenwallet/src/Models/Asset/AssetValidator.swift
@@ -23,8 +23,8 @@ let MAX_IPFSHASH_LENGTH = 46;
 
 let ROOT_NAME_CHARACTERS = try? NSRegularExpression(pattern: "^[A-Z0-9._]{3,}$", options: [])
 let SUB_NAME_CHARACTERS = try? NSRegularExpression(pattern: "^[A-Z0-9._]+$", options: [])
-let UNIQUE_TAG_CHARACTERS = try? NSRegularExpression(pattern: "^[-A-Za-z0-9@$%&*()\\{}_.?:]+$", options: [])
-let CHANNEL_TAG_CHARACTERS = try? NSRegularExpression(pattern: "^[A-Z0-9._]+$", options: [])
+let UNIQUE_TAG_CHARACTERS = try? NSRegularExpression(pattern: "^[-A-Za-z0-9@$%&*()[\\]{}_.?:]+$", options: [])
+let CHANNEL_TAG_CHARACTERS = try? NSRegularExpression(pattern: "^[A-Za-z0-9_]+$", options: [])
 
 let DOUBLE_PUNCTUATION = try? NSRegularExpression(pattern: "^.*[._]{2,}.*$", options: [])
 let LEADING_PUNCTUATION = try? NSRegularExpression(pattern: "^[._].*$", options: [])


### PR DESCRIPTION
Is this intentional?

Currently `CHANNEL_TAG_CHARACTERS` matches [VOTE_TAG_CHARACTERS](https://github.com/RavenProject/Ravencoin/blob/43785d640ad1a07bb1d55cdec3a9d716954cd531/src/assets/assets.cpp#L52) from the desktop wallet, I've updated it to match `MSGCHANNEL_TAG_CHARACTERS` from the desktop wallet instead.  
  
`UNIQUE_TAG_CHARACTERS` was missing a "[]"'s around the "\\\\"