### PR TITLE
Fixes issue with iPads only allowing 8 of 12 required words for wallet recovery

### DIFF
--- a/ravenwallet/BRAPIClient+Wallet.swift
+++ b/ravenwallet/BRAPIClient+Wallet.swift
@@ -54,7 +54,7 @@ extension BRAPIClient {
     //        task.resume()
     //    }
     
-    func ravenMultiplier(_ handler: @escaping (_ mult: Double, _ error: String?) -> Void) {
+    func ravenMultiplier(_ handler: @escaping (_ mult: Optional<Double>, _ error: String?) -> Void) {
         print("Getting rate from ravenMultiplierURL")
         let request = URLRequest(url: URL(string: ravenMultiplierURL)!)
         let task = dataTaskWithRequest(request) { (data, response, error) in

--- a/ravenwallet/Base.lproj/LaunchScreen.storyboard
+++ b/ravenwallet/Base.lproj/LaunchScreen.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17700" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="ipad12_9" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>

--- a/ravenwallet/src/ViewControllers/EnterPhraseCollectionViewController.swift
+++ b/ravenwallet/src/ViewControllers/EnterPhraseCollectionViewController.swift
@@ -22,7 +22,8 @@ class EnterPhraseCollectionViewController : UICollectionViewController {
         self.walletManager = walletManager
         let layout = UICollectionViewFlowLayout()
         let screenWidth = UIScreen.main.safeWidth
-        layout.itemSize = CGSize(width: (screenWidth - C.padding[4])/3.0, height: itemHeight)
+        if(E.isIPad) { layout.itemSize = CGSize(width: (screenWidth - C.padding[4])/4.0, height: itemHeight) }
+        else         { layout.itemSize = CGSize(width: (screenWidth - C.padding[4])/3.0, height: itemHeight) }
         layout.minimumLineSpacing = 0.0
         layout.minimumInteritemSpacing = 0.0
         layout.sectionInset = .zero

--- a/ravenwallet/src/Wallet/ExchangeUpdater.swift
+++ b/ravenwallet/src/Wallet/ExchangeUpdater.swift
@@ -27,8 +27,8 @@ class ExchangeUpdater : Subscriber {
     func refresh(completion: @escaping () -> Void) {
         
         walletManager.apiClient?.ravenMultiplier{multiplier, error in
-            guard let ratio_to_btc : Double = multiplier else { completion(); return }
-            self.walletManager.apiClient?.exchangeRates(code: self.currency.code, isFallback: false, ratio_to_btc, { rates,
+            guard let ratio_to_btc : Optional<Double> = multiplier else { completion(); return }
+            self.walletManager.apiClient?.exchangeRates(code: self.currency.code, isFallback: false, ratio_to_btc!, { rates,
                 ratio_to_btc, error in
                 
                 guard let currentRate = rates.first( where: { $0.code == Store.state.defaultCurrencyCode })


### PR DESCRIPTION
Recently discovered an issue where when starting with a new install on an iPad of any type or generation would only display 8 of the 12 necessary words needed to recover a previously created wallet. There was also an update to the swiftUI that also needed changes to allow the app to compile (see Optional<Double> changes and version updates).